### PR TITLE
Move TS back to dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,38 @@ jobs:
       - name: Build
         run: npm run build
 
+  # Functions need to be buildable without any dev dependencies and outside of
+  # the context of the npm workspace because this is how Firebase will build
+  # them at publish time.
+  build-release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        function:
+          - firestore-audit-document
+          - firestore-audit-log
+          - firestore-redact-text
+          - storage-file-intel
+    defaults:
+      run:
+        working-directory: ./${{ matrix.function }}/functions
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install dependencies
+        run: npm ci --omit=dev --no-workspaces
+
+      - name: Build
+        run: npm run build
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/firestore-audit-document/functions/package-lock.json
+++ b/firestore-audit-document/functions/package-lock.json
@@ -7,14 +7,15 @@
       "name": "firestore-sensitive-document-audit-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "pangea-node-sdk": "^1.2.0",
-        "rimraf": "^5.0.7"
+        "rimraf": "^5.0.7",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "@types/mkdirp": "^1.0.1",
         "firebase-functions-test": "^0.2.3",
@@ -23,8 +24,7 @@
         "image-type": "^4.1.0",
         "jest": "^29.7.0",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2144,8 +2144,7 @@
     "node_modules/@tsconfig/node18": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
-      "dev": true
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11336,7 +11335,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/firestore-audit-document/functions/package.json
+++ b/firestore-audit-document/functions/package.json
@@ -15,14 +15,15 @@
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {
+    "@tsconfig/node18": "^18.2.4",
     "@types/node": "^18.13.0",
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.1",
     "pangea-node-sdk": "^1.2.0",
-    "rimraf": "^5.0.7"
+    "rimraf": "^5.0.7",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.12",
     "@types/mkdirp": "^1.0.1",
     "firebase-functions-test": "^0.2.3",
@@ -31,8 +32,7 @@
     "image-type": "^4.1.0",
     "jest": "^29.7.0",
     "mocked-env": "^1.3.5",
-    "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.1.4"
   },
   "private": true
 }

--- a/firestore-audit-log/functions/package-lock.json
+++ b/firestore-audit-log/functions/package-lock.json
@@ -7,22 +7,22 @@
       "name": "firestore-audit-log-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "pangea-node-sdk": "^1.2.0",
-        "rimraf": "^5.0.7"
+        "rimraf": "^5.0.7",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.1.7",
         "firebase-tools": "^13.11.2",
         "jest": "^29.7.0",
         "js-yaml": "^3.13.1",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2132,8 +2132,7 @@
     "node_modules/@tsconfig/node18": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
-      "dev": true
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11292,7 +11291,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/firestore-audit-log/functions/package.json
+++ b/firestore-audit-log/functions/package.json
@@ -14,22 +14,22 @@
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {
+    "@tsconfig/node18": "^18.2.4",
     "@types/node": "^18.13.0",
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.1",
     "pangea-node-sdk": "^1.2.0",
-    "rimraf": "^5.0.7"
+    "rimraf": "^5.0.7",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.12",
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^13.11.2",
     "jest": "^29.7.0",
     "js-yaml": "^3.13.1",
     "mocked-env": "^1.3.5",
-    "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.1.4"
   },
   "private": true
 }

--- a/firestore-redact-text/functions/package-lock.json
+++ b/firestore-redact-text/functions/package-lock.json
@@ -7,22 +7,22 @@
       "name": "firestore-redact-text-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "pangea-node-sdk": "^1.2.0",
-        "rimraf": "^5.0.7"
+        "rimraf": "^5.0.7",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.1.7",
         "firebase-tools": "^13.11.2",
         "jest": "^29.7.0",
         "js-yaml": "^3.13.1",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2132,8 +2132,7 @@
     "node_modules/@tsconfig/node18": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
-      "dev": true
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11292,7 +11291,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/firestore-redact-text/functions/package.json
+++ b/firestore-redact-text/functions/package.json
@@ -14,22 +14,22 @@
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {
+    "@tsconfig/node18": "^18.2.4",
     "@types/node": "^18.13.0",
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.1",
     "pangea-node-sdk": "^1.2.0",
-    "rimraf": "^5.0.7"
+    "rimraf": "^5.0.7",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.12",
     "firebase-functions-test": "^0.1.7",
     "firebase-tools": "^13.11.2",
     "jest": "^29.7.0",
     "js-yaml": "^3.13.1",
     "mocked-env": "^1.3.5",
-    "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.1.4"
   },
   "private": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,15 @@
       "name": "firestore-sensitive-document-audit-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "pangea-node-sdk": "^1.2.0",
-        "rimraf": "^5.0.7"
+        "rimraf": "^5.0.7",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "@types/mkdirp": "^1.0.1",
         "firebase-functions-test": "^0.2.3",
@@ -37,8 +38,7 @@
         "image-type": "^4.1.0",
         "jest": "^29.7.0",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1697,7 +1697,6 @@
     },
     "firestore-audit-document/functions/node_modules/@tsconfig/node18": {
       "version": "18.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "firestore-audit-document/functions/node_modules/@types/babel__core": {
@@ -8306,22 +8305,22 @@
       "name": "firestore-audit-log-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "pangea-node-sdk": "^1.2.0",
-        "rimraf": "^5.0.7"
+        "rimraf": "^5.0.7",
+        "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.1.7",
         "firebase-tools": "^13.11.2",
         "jest": "^29.7.0",
         "js-yaml": "^3.13.1",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -9971,7 +9970,6 @@
     },
     "firestore-audit-log/functions/node_modules/@tsconfig/node18": {
       "version": "18.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "firestore-audit-log/functions/node_modules/@types/babel__core": {
@@ -16566,6 +16564,7 @@
       "name": "firestore-redact-text-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
@@ -16573,7 +16572,6 @@
         "rimraf": "^5.0.7"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.1.7",
         "firebase-tools": "^13.11.2",
@@ -18231,7 +18229,6 @@
     },
     "firestore-redact-text/functions/node_modules/@tsconfig/node18": {
       "version": "18.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "firestore-redact-text/functions/node_modules/@types/babel__core": {
@@ -32311,7 +32308,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32672,6 +32668,7 @@
       "name": "storage-file-intel-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "archiver": "^7.0.1",
         "archiver-zip-encrypted": "^2.0.0",
@@ -32683,7 +32680,6 @@
         "uuidv4": "^6.2.13"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.2.3",
         "firebase-tools": "^13.11.2",
@@ -34375,7 +34371,6 @@
     },
     "storage-file-intel/functions/node_modules/@tsconfig/node18": {
       "version": "18.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "storage-file-intel/functions/node_modules/@types/babel__core": {

--- a/storage-file-intel/functions/package-lock.json
+++ b/storage-file-intel/functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "storage-file-intel-functions",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.13.0",
         "archiver": "^7.0.1",
         "archiver-zip-encrypted": "^2.0.0",
@@ -15,10 +16,10 @@
         "mkdirp": "^3.0.1",
         "pangea-node-sdk": "^1.2.0",
         "rimraf": "^5.0.7",
+        "typescript": "^5.4.5",
         "uuidv4": "^6.2.13"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
         "firebase-functions-test": "^0.2.3",
         "firebase-tools": "^13.11.2",
@@ -26,8 +27,7 @@
         "image-type": "^4.1.0",
         "jest": "^29.7.0",
         "mocked-env": "^1.3.5",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
+        "ts-jest": "^29.1.4"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2174,8 +2174,7 @@
     "node_modules/@tsconfig/node18": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
-      "dev": true
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11540,7 +11539,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/storage-file-intel/functions/package.json
+++ b/storage-file-intel/functions/package.json
@@ -15,6 +15,7 @@
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {
+    "@tsconfig/node18": "^18.2.4",
     "@types/node": "^18.13.0",
     "archiver": "^7.0.1",
     "archiver-zip-encrypted": "^2.0.0",
@@ -23,10 +24,10 @@
     "mkdirp": "^3.0.1",
     "pangea-node-sdk": "^1.2.0",
     "rimraf": "^5.0.7",
+    "typescript": "^5.4.5",
     "uuidv4": "^6.2.13"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.12",
     "firebase-functions-test": "^0.2.3",
     "firebase-tools": "^13.11.2",
@@ -34,8 +35,7 @@
     "image-type": "^4.1.0",
     "jest": "^29.7.0",
     "mocked-env": "^1.3.5",
-    "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.1.4"
   },
   "private": true
 }


### PR DESCRIPTION
It's undocumented but Firebase builds functions without their dev dependencies at publish time, so we need to move TypeScript back to regular dependencies. Also add a CI job that validates this.