### PR TITLE
storage-file-intel: fix malicious file isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,6 +4731,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.2.tgz",
+      "integrity": "sha512-KmROQqbQzKGuaAbmK+ZcytkJ51+YqDa7NmbXjmtC5YBLSyQYo21YaUnQ3HbaPFKL1ooo6RQ6OPYPIDyxfpDDXw==",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4967,6 +4975,14 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/request": {
       "version": "2.48.12",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
@@ -5039,6 +5055,11 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -16771,7 +16792,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tsconfig/node18": "^18.2.4",
+        "@types/archiver": "^6.0.2",
         "@types/node": "^18.19.39",
+        "@types/uuid": "^10.0.0",
         "archiver": "^7.0.1",
         "archiver-zip-encrypted": "^2.0.0",
         "firebase-admin": "^11.11.1",
@@ -16780,7 +16803,7 @@
         "pangea-node-sdk": "^1.10.0",
         "rimraf": "^5.0.7",
         "typescript": "^5.5.2",
-        "uuidv4": "^6.2.13"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -16862,10 +16885,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "storage-file-intel/functions/node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "license": "MIT"
     },
     "storage-file-intel/functions/node_modules/aes-js": {
       "version": "3.1.2",
@@ -17239,17 +17258,14 @@
         }
       }
     },
-    "storage-file-intel/functions/node_modules/uuidv4": {
-      "version": "6.2.13",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
-    },
-    "storage-file-intel/functions/node_modules/uuidv4/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+    "storage-file-intel/functions/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/storage-file-intel/CHANGELOG.md
+++ b/storage-file-intel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.1
+
+Fixed isolation of malicious files.
+
 ## Version 0.2.0
 
 Updated to Node.js v18.

--- a/storage-file-intel/extension.yaml
+++ b/storage-file-intel/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-file-intel
-version: 0.2.0
+version: 0.2.1
 specVersion: v1beta
 
 displayName: Known Malware Detection

--- a/storage-file-intel/functions/package-lock.json
+++ b/storage-file-intel/functions/package-lock.json
@@ -8,7 +8,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tsconfig/node18": "^18.2.4",
+        "@types/archiver": "^6.0.2",
         "@types/node": "^18.19.39",
+        "@types/uuid": "^10.0.0",
         "archiver": "^7.0.1",
         "archiver-zip-encrypted": "^2.0.0",
         "firebase-admin": "^11.11.1",
@@ -17,7 +19,7 @@
         "pangea-node-sdk": "^1.10.0",
         "rimraf": "^5.0.7",
         "typescript": "^5.5.2",
-        "uuidv4": "^6.2.13"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -906,6 +908,19 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@google-cloud/cloud-sql-connector/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-6.8.0.tgz",
@@ -1275,6 +1290,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google-cloud/storage": {
@@ -2174,6 +2202,14 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
       "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.2.tgz",
+      "integrity": "sha512-KmROQqbQzKGuaAbmK+ZcytkJ51+YqDa7NmbXjmtC5YBLSyQYo21YaUnQ3HbaPFKL1ooo6RQ6OPYPIDyxfpDDXw==",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2426,6 +2462,14 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/request": {
       "version": "2.48.12",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
@@ -2508,9 +2552,9 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -5127,6 +5171,18 @@
         "@google-cloud/storage": "^6.9.5"
       }
     },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/firebase-functions": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
@@ -5966,6 +6022,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -11018,6 +11087,19 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "optional": true
     },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -11500,30 +11582,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/uuidv4": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/uuidv4/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/storage-file-intel/functions/package.json
+++ b/storage-file-intel/functions/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "@tsconfig/node18": "^18.2.4",
+    "@types/archiver": "^6.0.2",
     "@types/node": "^18.19.39",
+    "@types/uuid": "^10.0.0",
     "archiver": "^7.0.1",
     "archiver-zip-encrypted": "^2.0.0",
     "firebase-admin": "^11.11.1",
@@ -25,7 +27,7 @@
     "pangea-node-sdk": "^1.10.0",
     "rimraf": "^5.0.7",
     "typescript": "^5.5.2",
-    "uuidv4": "^6.2.13"
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/storage-file-intel/functions/src/archiver.d.ts
+++ b/storage-file-intel/functions/src/archiver.d.ts
@@ -1,1 +1,0 @@
-declare module "archiver";

--- a/storage-file-intel/functions/src/isolate-file.ts
+++ b/storage-file-intel/functions/src/isolate-file.ts
@@ -20,14 +20,14 @@ import * as logs from "./logs";
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
-import * as Archiver from "archiver";
-import * as ArchiverEncrypted from "archiver-zip-encrypted";
+import archiver from "archiver";
+import archiverZipEncrypted from "archiver-zip-encrypted";
 if (config.zipPassword !== undefined)
-  Archiver.registerFormat("zip-encrypted", ArchiverEncrypted);
+  archiver.registerFormat("zip-encrypted", archiverZipEncrypted);
 
 import { Bucket } from "@google-cloud/storage";
 import { storage } from "firebase-functions";
-import { uuid } from "uuidv4";
+import { v4 as uuid } from "uuid";
 
 export interface IsolateFileResult {
   outputFilePath: string;
@@ -100,12 +100,12 @@ export const isolateFile = async ({
 
       let archive;
       if (config.zipPassword === undefined) {
-        archive = Archiver("zip", {
-          zlib: { level: 8 },
-        });
+        archive = archiver("zip", { zlib: { level: 8 } });
       } else {
         // create archive and specify method of encryption and password
-        archive = Archiver.create("zip-encrypted", {
+        // @ts-expect-error "zip-encrypted" has been registered as a custom
+        // format.
+        archive = archiver("zip-encrypted", {
           zlib: { level: 8 },
           encryptionMethod: "aes256",
           password: config.zipPassword,


### PR DESCRIPTION
Remove usage of "raw" and "verbose" since they are not needed. Just pass on the parameters we know we used to the metadata.

Replace the deprecated uuidv4 module with uuid.

Fix usage of archive in the passworded case.